### PR TITLE
Added NPM version warning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ Simple starter example that gets you going with Angular 2 in minutes.
 This sample intentionally uses precise versions of Angular 2 and SystemJS so new versions do not break it. I will update these as Angular 2 moves out of Alpha.
 
 This uses the Path Routing Strategy (HTML5 Mode in Angular 1). This is ideal, however since this demo strives for a simple server using live-server, if you refresh the browser when on a deep link (a named route), you will get a 404. Simply go back to the root /.
+
+To avoid errors in `npm install` use `npm version >2.14.x`


### PR DESCRIPTION
Checkout README.md for `npm version >2.14.x` warning.

npm install not working in lower version of npm leading to `@reactivex/rxjs` invalid package error.