### PR TITLE
Correct "clone into" directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Super simple Angular 2 app with 1 module and 2 routes
 
 ```
-git clone https://github.com/johnpapa/angular2-go.git a2-go
+git clone https://github.com/johnpapa/angular2-go.git
 cd angular2-go
 npm i
 npm start


### PR DESCRIPTION
The name of a new directory to clone into is different than the target directory.
